### PR TITLE
sepolicy: Unlabel aux camera whitelist prop

### DIFF
--- a/qva/private/property_contexts
+++ b/qva/private/property_contexts
@@ -35,7 +35,6 @@ ro.vendor.btstack.                         u:object_r:bluetooth_prop:s0
 vendor.pts.                                u:object_r:bluetooth_prop:s0
 vendor.bt.pts.                             u:object_r:bluetooth_prop:s0
 vendor.bluetooth.                          u:object_r:bluetooth_prop:s0
-vendor.camera.aux.packagelist              u:object_r:persist_camera_prop:s0
 persist.vendor.camera.privapp.list         u:object_r:persist_camera_prop:s0
 
 #mm-parser


### PR DESCRIPTION
 * This will be properly labeled in device/aosip/sepolicy
   to make it readable to everything on every device

Change-Id: Idec6cad06c51ba73519f61e95c74e1c8915d301b