### PR TITLE
sepolicy-legacy-um: Allow Snap to read camera props

### DIFF
--- a/vendor/common/app.te
+++ b/vendor/common/app.te
@@ -12,3 +12,6 @@ allow appdomain qti_logkit_pub_socket:dir r_dir_perms;
 
 # Allow all apps to open and send ioctl to npu device
 allow appdomain npu_device:chr_file r_file_perms;
+
+# Allow reading camera props
+get_prop(appdomain, camera_prop)


### PR DESCRIPTION
02-25 21:38:31.023  2757  2757 W .lineageos.snap: type=1400 audit(0.0:43): avc: denied { read } for name="u:object_r:camera_prop:s0" dev="tmpfs" ino=7213 scontext=u:r:snap_app:s0:c512,c768 tcontext=u:object_r:camera_prop:s0 tclass=file permissive=0 app=org.lineageos.snap
02-25 21:38:31.028  2757  2757 E libc    : Access denied finding property "camera.qcom.misc.disable"

Change-Id: I0c554b9785b28aa276ffd7864905a07f67b33aba
Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>