### PR TITLE
sepolicy: Allow system_server to read persist camera props

### DIFF
--- a/generic/vendor/common/system_server.te
+++ b/generic/vendor/common/system_server.te
@@ -52,4 +52,7 @@ get_prop(system_server, vendor_display_prop)
 # allow system_server to read/acess peripheral manager.
 get_prop(system_server, vendor_per_mgr_state_prop);
 
+# allow system server to get vendor_camera_prop
+get_prop(system_server, vendor_camera_prop)
+
 hal_client_domain(system_server, hal_dataconnection_qti)

--- a/legacy/vendor/common/system_server.te
+++ b/legacy/vendor/common/system_server.te
@@ -177,5 +177,8 @@ get_prop(system_server, vendor_iop_prop)
 # allow system server to get vendor_audio_prop
 get_prop(system_server, vendor_audio_prop)
 
+# allow system server to get vendor_camera_prop
+get_prop(system_server, vendor_camera_prop)
+
 # allow system_server to access IWifiStats HAL service
 hal_client_domain(system_server, hal_wifilearner)

--- a/qva/private/system_server.te
+++ b/qva/private/system_server.te
@@ -65,3 +65,5 @@ allow system_server qspmsvc_service:service_manager find;
 # Allow system server to access for dpm
 get_prop(system_server, persist_dpm_prop)
 
+# allow system server to get persist_camera_prop
+get_prop(system_server, persist_camera_prop)


### PR DESCRIPTION
 * For qva, as per 1b99037858a0fa24014e49a413f5934bb8ea8864,vendor.camera.aux.packagelist is no longer labeled
   as vendor_camera_prop.

Change-Id: I43a2404d9399a931b03e1d2c8589d0d4adb10fc3