### PR TITLE
Revert "sepolicy: Allow system_server to read persist camera props"

### DIFF
--- a/generic/vendor/common/system_server.te
+++ b/generic/vendor/common/system_server.te
@@ -52,7 +52,4 @@ get_prop(system_server, vendor_display_prop)
 # allow system_server to read/acess peripheral manager.
 get_prop(system_server, vendor_per_mgr_state_prop);
 
-# allow system server to get vendor_camera_prop
-get_prop(system_server, vendor_camera_prop)
-
 hal_client_domain(system_server, hal_dataconnection_qti)

--- a/legacy/vendor/common/system_server.te
+++ b/legacy/vendor/common/system_server.te
@@ -177,8 +177,5 @@ get_prop(system_server, vendor_iop_prop)
 # allow system server to get vendor_audio_prop
 get_prop(system_server, vendor_audio_prop)
 
-# allow system server to get vendor_camera_prop
-get_prop(system_server, vendor_camera_prop)
-
 # allow system_server to access IWifiStats HAL service
 hal_client_domain(system_server, hal_wifilearner)

--- a/qva/private/system_server.te
+++ b/qva/private/system_server.te
@@ -65,5 +65,3 @@ allow system_server qspmsvc_service:service_manager find;
 # Allow system server to access for dpm
 get_prop(system_server, persist_dpm_prop)
 
-# allow system server to get persist_camera_prop
-get_prop(system_server, persist_camera_prop)


### PR DESCRIPTION
Reverts DerpLab/device_qcom_sepolicy#5

this is not required and we should not use it as reverted by los also